### PR TITLE
Fix SetRecords not working with no existing records

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,7 +58,7 @@ func (p *Provider) updateRecord(ctx context.Context, oldRec netlifyDNSRecord, ne
 }
 
 // getDNSRecords gets all record in a zone. It returns an array of the records
-// in the zone
+// in the zone. It may return an empty slice and a nil error.
 func (p *Provider) getDNSRecords(ctx context.Context, zoneInfo netlifyZone, rec libdns.Record, matchContent bool) ([]netlifyDNSRecord, error) {
 	qs := make(url.Values)
 	qs.Set("type", rec.Type)
@@ -80,9 +80,6 @@ func (p *Provider) getDNSRecords(ctx context.Context, zoneInfo netlifyZone, rec 
 		if res.Hostname == libdns.AbsoluteName(rec.Name, zoneInfo.Name) && res.Type == rec.Type {
 			rest_to_return = append(rest_to_return, res)
 		}
-	}
-	if len(rest_to_return) == 0 {
-		return nil, fmt.Errorf("Can't find DNS record %s", libdns.AbsoluteName(rec.Name, zoneInfo.Name))
 	}
 	if err != nil {
 		return nil, err

--- a/provider.go
+++ b/provider.go
@@ -88,6 +88,9 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 			if err != nil {
 				return nil, err
 			}
+			if len(exactMatches) == 0 {
+				return nil, fmt.Errorf("can't find DNS record %s", libdns.AbsoluteName(rec.Name, zoneInfo.Name))
+			}
 			for _, rec := range exactMatches {
 				deleteQueue = append(deleteQueue, rec.libdnsRecord(zone))
 			}
@@ -99,6 +102,10 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 			reqURL := fmt.Sprintf("%s/dns_zones/%s/dns_records/%s", baseURL, zoneInfo.ID, delRec.ID)
 
 			req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+			if err != nil {
+				return nil, err
+			}
+
 			var result netlifyDNSRecord
 			err = p.doAPIRequest(req, false, false, true, true, &result)
 			if err != nil {


### PR DESCRIPTION
This commit fixes a bug where SetRecords will error out if there are no matching DNS records to be found instead of creating new ones.

This bug is caused by Client.getDNSRecords always erroring out when it cannot return anything, while SetRecords expects an empty slice to be returned with no error.

The fix is to make getDNSRecords not error out when there's nothing to return.

The other use of getDNSRecords, which is in DeleteRecords, has been updated to check whether the returned slice is empty. This is the only other use of getDNSRecords.